### PR TITLE
StatusPage: correcetly display lists and padding/margin before or after h2 and h3 titles

### DIFF
--- a/statuscake-page-customisation.css
+++ b/statuscake-page-customisation.css
@@ -67,3 +67,23 @@ a:focus, a:hover {
 .singleton-container.opened {
     padding: 15px 0 !important;
 }
+
+/* .timeline => Events#show page, .content => Events#index page */
+.timeline li.entry ul li, .content ul li {
+  margin-left: 1em;
+  margin-bottom: 8px;
+}
+
+.timeline li.entry ul li li, .content ul li li {
+  margin-left: 2em;
+}
+
+.timeline h2, .content h2 {
+  padding-bottom: 8px;
+  margin-bottom: 16px;
+}
+
+.timeline h3, .content h3 {
+  padding-bottom: 8px;
+  margin-bottom: 16px;
+}


### PR DESCRIPTION
* https://scalingostatus.com/event/202008/
* https://scalingostatus.com/details/708b47b2ba7a0